### PR TITLE
自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -5,7 +5,7 @@ $(function(){
         `<div class="message" data-message-id=${message.id}>
           <div class="message__info">
             <div class="message__info__name">
-              ${message.user.name}
+              ${message.user_name}
             </div>
             <div class="message__info__date">
               ${message.created_at}
@@ -16,7 +16,7 @@ $(function(){
               ${message.content}
             </p>
           </div>
-          <img src=${message.image}>
+            <img src=${message.image}>
         </div>`
       return html;
     } else{
@@ -40,7 +40,7 @@ $(function(){
     };
   }
     var reloadMessages = function() {
-      var last_message_id = $('.message:last').data("message.id");
+      var last_message_id = $('.message:last').data("message-id");
       $.ajax({
         url: "api/messages",
         type: 'get',
@@ -48,11 +48,14 @@ $(function(){
         data: {id: last_message_id}
       })
       .done(function(messages) {
-        var insertHTML = '';
-        $.each(messages, function(i, message) {
-          insertHTML += buildHTML(message)
-        });
-        $('.messages').append(insertHTML);
+        if (messages.length !== 0) {
+          var insertHTML = '';
+          $.each(messages, function(i, message) {
+            insertHTML += buildHTML(message)
+          });
+          $('.messages').append(insertHTML);
+          $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+        }
       })
       .fail(function() {
         alert('error');
@@ -72,17 +75,17 @@ $(function(){
       contentType: false,
     })
     .done(function(data){
-      console.log(data)
       var html = buildHTML(data);
       $('.messages').append(html);
       $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
       $('form')[0].reset();
       $('.submit-btn').prop('disabled', false);
-      console.log(html)
     })
     .fail(function() {
       alert("メッセージ送信に失敗しました");
   });
   });
-  setInterval(reloadMessages, 7000);
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,27 +1,27 @@
 $(function(){
-     function buildHTML(message){
-      if (message.image){
-        var html =
-         `<div class="message">
-            <div class="message__info"
-              <div class=message__info__name">
-                ${message.user_name}
-              </div>
-              <div class="message__info__date">
-                ${message.created_at}
-              </div>
+  function buildHTML(message){
+    if (message.image){
+      var html =
+        `<div class="message" data-message-id=${message.id}>
+          <div class="message__info">
+            <div class="message__info__name">
+              ${message.user.name}
             </div>
-            <div class="message__text">
-              <p class="lower-message__content">
-                ${message.content}
-              </p>
+            <div class="message__info__date">
+              ${message.created_at}
             </div>
-            <img src=${message.image}>
-          </div>`
-        return html;
-      } else{
-        var html =
-        `<div class="message">
+          </div>
+          <div class="message__text">
+            <p class="lower-message__content">
+              ${message.content}
+            </p>
+          </div>
+          <img src=${message.image}>
+        </div>`
+      return html;
+    } else{
+      var html =
+        `<div class="message" data-message-id=${message.id}>
           <div class="message__info">
             <div class=message__info__name">
               ${message.user_name}
@@ -36,9 +36,29 @@ $(function(){
             </p>
           </div>
         </div>`
-        return html;
-      };
-    }
+      return html;
+    };
+  }
+    var reloadMessages = function() {
+      var last_message_id = $('.message:last').data("message.id");
+      $.ajax({
+        url: "api/messages",
+        type: 'get',
+        dataType: 'json',
+        data: {id: last_message_id}
+      })
+      .done(function(messages) {
+        var insertHTML = '';
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        $('.messages').append(insertHTML);
+      })
+      .fail(function() {
+        alert('error');
+      });
+    };
+
   $("#new_message").on('submit', function(e){
     e.preventDefault()
     var formData = new FormData(this);
@@ -52,14 +72,17 @@ $(function(){
       contentType: false,
     })
     .done(function(data){
+      console.log(data)
       var html = buildHTML(data);
       $('.messages').append(html);
       $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
       $('form')[0].reset();
       $('.submit-btn').prop('disabled', false);
+      console.log(html)
     })
     .fail(function() {
       alert("メッセージ送信に失敗しました");
   });
-  })
+  });
+  setInterval(reloadMessages, 7000);
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -23,7 +23,7 @@ $(function(){
       var html =
         `<div class="message" data-message-id=${message.id}>
           <div class="message__info">
-            <div class=message__info__name">
+            <div class="message__info__name">
               ${message.user_name}
             </div>
             <div class="message__info__date">

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -4,3 +4,4 @@ json.array! @messages do |message|
   json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
   json.user_name message.user.name
   json.id message.id
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,6 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {message: {id: message.id}}}
   .message__info
     .message__info__name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.user_name @message.user.name
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.content @message.content
 json.image @message.image_url
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:index, :new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: {format: 'json'}
+    end
   end
 end


### PR DESCRIPTION
# WHAT
  自動更新機能実装で別のユーザーの投稿メッセージもリロードしなくても更新ができるようにする。自動でチャット画面が更新されるようにする。

- 何秒かおきに、JavaScriptを使ってブラウザに表示されているメッセージのうち最も新しいもののidをリクエストとして送る
- Railsのコントローラのアクションにてデータベースに保存されている最新のメッセージのidと送信したidを比較し、大きいidを持つメッセージたちをレスポンスする
- JavaScriptを使って、レスポンスに含まれるメッセージたちをメッセージ一覧の最後に追加する

# WHY

自動更新機能をつけることでチャット機能に重要な他人のメッセージが自動的に更新、表示されより使いやすくなるため。

### 画像、文字の同時投稿時
  https://gyazo.com/7c14ad535796d455a7a919cae6ac6ca1
### 文字のみの投稿時
  https://gyazo.com/274b31fdf6f6bb28b92d738d2296455b
### 画像のみの投稿時
 https://gyazo.com/3b0318ecb4a84ae47372f5e60d76beb2